### PR TITLE
Upgrade to Ant v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,27 +12,32 @@
         "tinycolor2": "^1.4.1"
       }
     },
-    "@ant-design/create-react-context": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@ant-design/create-react-context/-/create-react-context-0.2.5.tgz",
-      "integrity": "sha512-1rMAa4qgP2lfl/QBH9i78+Gjxtj9FTMpMyDGZsEBW5Kih72EuUo9958mV8PgpRkh4uwPSQ7vVZWXeyNZXVAFDg==",
-      "requires": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      }
-    },
     "@ant-design/icons": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-2.1.1.tgz",
-      "integrity": "sha512-jCH+k2Vjlno4YWl6g535nHR09PwCEmTBKAG6VqF+rhkrSPRLfgpU2maagwbZPLjaHuU5Jd1DFQ2KJpQuI6uG8w=="
-    },
-    "@ant-design/icons-react": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons-react/-/icons-react-2.0.1.tgz",
-      "integrity": "sha512-r1QfoltMuruJZqdiKcbPim3d8LNsVPB733U0gZEUSxBLuqilwsW28K2rCTWSMTjmFX7Mfpf+v/wdiFe/XCqThw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.0.0.tgz",
+      "integrity": "sha512-oJTNTyo/6DjVmK/DSa58A+7gZRGgzBCAEJ9Pfa6U+BAZO28tvOE3YzlQd9gq9Qu6d47JL1ixyID3qsmRFqitlQ==",
       "requires": {
         "@ant-design/colors": "^3.1.0",
-        "babel-runtime": "^6.26.0"
+        "@ant-design/icons-svg": "^4.0.0",
+        "classnames": "^2.2.6",
+        "insert-css": "^2.0.0",
+        "rc-util": "^4.9.0"
+      }
+    },
+    "@ant-design/icons-svg": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.0.0.tgz",
+      "integrity": "sha512-Nai+cd3XUrv/z50gSk1FI08j6rENZ1e93rhKeLTBGwa5WrmHvhn2vowa5+voZW2qkXJn1btS6tdvTEDB90M0Pw=="
+    },
+    "@ant-design/react-slick": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-0.25.5.tgz",
+      "integrity": "sha512-fusHR9LkarCARvYTN6cG3yz2/Ogf+HTaJ2XEihIjsjgm6uE1aSXycRFEVDpOFP1Aib51Z2Iz3tgg/gL+WbK8rQ==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "json2mq": "^0.2.0",
+        "lodash": "^4.17.15",
+        "resize-observer-polyfill": "^1.5.0"
       }
     },
     "@babel/code-frame": {
@@ -3116,7 +3121,8 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
     },
     "@types/q": {
       "version": "1.5.2",
@@ -3128,6 +3134,7 @@
       "version": "16.9.19",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.19.tgz",
       "integrity": "sha512-LJV97//H+zqKWMms0kvxaKYJDG05U2TtQB3chRLF8MPNs+MQh/H1aGlyDUxjaHvu08EAGerdX2z4LTBc7ns77A==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -3182,14 +3189,6 @@
         "@types/history": "*",
         "@types/react": "*",
         "@types/react-router": "*"
-      }
-    },
-    "@types/react-slick": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/@types/react-slick/-/react-slick-0.23.4.tgz",
-      "integrity": "sha512-vXoIy4GUfB7/YgqubR4H7RALo+pRdMYCeLgWwV3MPwl5pggTlEkFBTF19R7u+LJc85uMqC7RfsbkqPLMQ4ab+A==",
-      "requires": {
-        "@types/react": "*"
       }
     },
     "@types/redux-mock-store": {
@@ -3700,62 +3699,53 @@
       }
     },
     "antd": {
-      "version": "3.26.9",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-3.26.9.tgz",
-      "integrity": "sha512-youf+hBJHB4nuhV7yEbm2VQSMtX9RxrNQvjlc+iIPj4FeJsuTQXIfSSAc5GhwDeVAI4+nuapCv7XLFIQ+f2ZFg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-4.0.0.tgz",
+      "integrity": "sha512-sfaxNqqtaGg+5JWucSPM0Nr3eBh5gUBlmsH5RqdtpcP5qTM2NOxcmhx3I8KlSs5O39jAZ6nRVmjubjpw3GS5oQ==",
       "requires": {
-        "@ant-design/create-react-context": "^0.2.4",
-        "@ant-design/icons": "~2.1.1",
-        "@ant-design/icons-react": "~2.0.1",
-        "@types/react-slick": "^0.23.4",
+        "@ant-design/icons": "^4.0.0-rc.0",
+        "@ant-design/react-slick": "~0.25.5",
         "array-tree-filter": "^2.1.0",
-        "babel-runtime": "6.x",
         "classnames": "~2.2.6",
         "copy-to-clipboard": "^3.2.0",
         "css-animation": "^1.5.0",
-        "dom-closest": "^0.2.0",
-        "enquire.js": "^2.1.6",
-        "is-mobile": "^2.1.0",
         "lodash": "^4.17.13",
         "moment": "^2.24.0",
         "omit.js": "^1.0.2",
         "prop-types": "^15.7.2",
         "raf": "^3.4.1",
-        "rc-animate": "^2.10.2",
-        "rc-calendar": "~9.15.7",
-        "rc-cascader": "~0.17.4",
+        "rc-animate": "~2.10.2",
+        "rc-cascader": "~1.0.0",
         "rc-checkbox": "~2.1.6",
         "rc-collapse": "~1.11.3",
         "rc-dialog": "~7.6.0",
         "rc-drawer": "~3.1.1",
-        "rc-dropdown": "~2.4.1",
-        "rc-editor-mention": "^1.1.13",
-        "rc-form": "^2.4.10",
-        "rc-input-number": "~4.5.0",
-        "rc-mentions": "~0.4.0",
-        "rc-menu": "~7.5.1",
-        "rc-notification": "~3.3.1",
-        "rc-pagination": "~1.20.11",
+        "rc-dropdown": "~3.0.0",
+        "rc-field-form": "~1.0.0",
+        "rc-input-number": "~4.5.4",
+        "rc-mentions": "~1.0.0",
+        "rc-menu": "~8.0.1",
+        "rc-notification": "~4.0.0",
+        "rc-pagination": "~2.0.1",
+        "rc-picker": "~1.1.0",
         "rc-progress": "~2.5.0",
-        "rc-rate": "~2.5.0",
+        "rc-rate": "~2.5.1",
         "rc-resize-observer": "^0.1.0",
-        "rc-select": "~9.2.0",
-        "rc-slider": "~8.7.1",
+        "rc-select": "~10.0.0",
+        "rc-slider": "~9.2.1",
         "rc-steps": "~3.5.0",
         "rc-switch": "~1.9.0",
-        "rc-table": "~6.10.5",
-        "rc-tabs": "~9.7.0",
-        "rc-time-picker": "~3.7.1",
-        "rc-tooltip": "~3.7.3",
-        "rc-tree": "~2.1.0",
-        "rc-tree-select": "~2.9.1",
-        "rc-trigger": "^2.6.2",
-        "rc-upload": "~2.9.1",
-        "rc-util": "^4.16.1",
-        "react-lazy-load": "^3.0.13",
-        "react-lifecycles-compat": "^3.0.4",
-        "react-slick": "~0.25.2",
+        "rc-table": "~7.0.0",
+        "rc-tabs": "~10.0.0",
+        "rc-tooltip": "~4.0.0",
+        "rc-tree": "~3.0.0",
+        "rc-tree-select": "~3.0.0",
+        "rc-trigger": "~4.0.0",
+        "rc-upload": "~3.0.0",
+        "rc-util": "^4.20.0",
+        "rc-virtual-list": "~1.0.0",
         "resize-observer-polyfill": "^1.5.1",
+        "scroll-into-view-if-needed": "^2.2.20",
         "shallowequal": "^1.1.0",
         "warning": "~4.0.3"
       }
@@ -4019,7 +4009,8 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -4093,9 +4084,9 @@
       "dev": true
     },
     "async-validator": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-1.11.5.tgz",
-      "integrity": "sha512-XNtCsMAeAH1pdLMEg1z8/Bb3a8cdCbui9QbJATRFHHHW5kT6+NPI3zSVQUXgikTFITzsg+kYY5NTWhM2Orwt9w=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-3.2.3.tgz",
+      "integrity": "sha512-yMJ4i3x5qEGVgEMowZiBkx+rjDrsXf64BWdHENCtHLgyPiEE+2r8jvqMF1cghCgdGo4sWVLJ7MDwPQgGSPDCcw=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -5563,6 +5554,11 @@
         }
       }
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.13.tgz",
+      "integrity": "sha512-o+w9w7A98aAFi/GjK8cxSV+CdASuPa2rR5UWs3+yHkJzWqaKoBEufFNWYaXInCSmUfDCVhesG+v9MTWqOjsxFg=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5667,9 +5663,9 @@
       "dev": true
     },
     "copy-to-clipboard": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.2.1.tgz",
-      "integrity": "sha512-btru1Q6RD9wbonIvEU5EfnhIRGHLo//BGXQ1hNAD2avIs/nBZlpbOeKtv3mhoUByN4DB9Cb6/vXBymj1S43KmA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
       "requires": {
         "toggle-selection": "^1.0.6"
       }
@@ -5751,16 +5747,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "create-react-class": {
-      "version": "15.6.3",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
-      "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
       }
     },
     "cross-spawn": {
@@ -6088,7 +6074,8 @@
     "csstype": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
-      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA=="
+      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==",
+      "dev": true
     },
     "customize-cra": {
       "version": "0.9.1",
@@ -6343,6 +6330,11 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "dev": true
+    },
+    "dayjs": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.21.tgz",
+      "integrity": "sha512-1kbWK0hziklUHkGgiKr7xm59KwAg/K3Tp7H/8X+f58DnNCwY3pKYjOCJpIlVs125FRBukGVZdKZojC073D0IeQ=="
     },
     "debug": {
       "version": "3.1.0",
@@ -6773,14 +6765,6 @@
       "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.10.4.tgz",
       "integrity": "sha512-wytDzaru67AmqFOY4B9GUb/hrwWagezoYYK97D/vpK+ezg+cnuZO0Q2gltUPa7KfNmIqfRIYVCF8UhRDEHAmgQ=="
     },
-    "dom-closest": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/dom-closest/-/dom-closest-0.2.0.tgz",
-      "integrity": "sha1-69n5HRvyLo1vR3h2u80+yQIWwM8=",
-      "requires": {
-        "dom-matches": ">=1.0.1"
-      }
-    },
     "dom-converter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
@@ -6789,16 +6773,6 @@
       "requires": {
         "utila": "~0.4"
       }
-    },
-    "dom-matches": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-matches/-/dom-matches-2.0.0.tgz",
-      "integrity": "sha1-0nKLQWqHUzmA6wibhI0lPPI6dYw="
-    },
-    "dom-scroll-into-view": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz",
-      "integrity": "sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4="
     },
     "dom-serializer": {
       "version": "0.2.2",
@@ -6878,16 +6852,6 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
-    },
-    "draft-js": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.10.5.tgz",
-      "integrity": "sha512-LE6jSCV9nkPhfVX2ggcRLA4FKs6zWq9ceuO/88BpXdNCS7mjRTgs0NsV6piUCJX9YxMsB9An33wnkMmU2sD2Zg==",
-      "requires": {
-        "fbjs": "^0.8.15",
-        "immutable": "~3.7.4",
-        "object-assign": "^4.1.0"
-      }
     },
     "duplexer": {
       "version": "0.1.1",
@@ -6977,6 +6941,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -7012,11 +6977,6 @@
           }
         }
       }
-    },
-    "enquire.js": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
-      "integrity": "sha1-PoeAybi4NQhMP2DhZtvDwqPImBQ="
     },
     "entities": {
       "version": "2.0.0",
@@ -7689,11 +7649,6 @@
       "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
       "dev": true
     },
-    "eventlistener": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/eventlistener/-/eventlistener-0.0.1.tgz",
-      "integrity": "sha1-7Suqu4UiJ68rz4iRUscsY8pTLrg="
-    },
     "events": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
@@ -8285,35 +8240,6 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
-      }
-    },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        },
-        "promise": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "~2.0.3"
-          }
-        }
       }
     },
     "fd-slicer": {
@@ -9587,6 +9513,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -9639,11 +9566,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
       "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==",
       "dev": true
-    },
-    "immutable": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
-      "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -9805,6 +9727,11 @@
           }
         }
       }
+    },
+    "insert-css": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/insert-css/-/insert-css-2.0.0.tgz",
+      "integrity": "sha1-610Ql7dUL0x56jBg067gfQU4gPQ="
     },
     "internal-ip": {
       "version": "4.3.0",
@@ -10033,11 +9960,6 @@
         "is-path-inside": "^1.0.0"
       }
     },
-    "is-mobile": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.2.0.tgz",
-      "integrity": "sha512-K0DmUqaZqYl6M8ej536uJYAQaBkx+qWph7xl1KRBr31UiGUT0MoFWUoqnIxzXnIeolnK8bkxtKXkZNL6HfSHhQ=="
-    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -10145,7 +10067,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.5",
@@ -10206,15 +10129,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -12930,11 +12844,6 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
     "lodash.flow": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
@@ -12983,11 +12892,6 @@
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
-    },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "lodash.toarray": {
       "version": "4.4.0",
@@ -13535,11 +13439,6 @@
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
-    "mutationobserver-shim": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
-      "integrity": "sha512-gciOLNN8Vsf7YzcqRjKzlAJ6y7e+B86u7i3KXes0xfxx/nfLmozlW1Vn+Sc9x3tPIePFgc1AeIFhtRgkqTjzDQ=="
-    },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -13631,6 +13530,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
       "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
+      "dev": true,
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -16632,20 +16532,20 @@
       }
     },
     "rc-align": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-2.4.5.tgz",
-      "integrity": "sha512-nv9wYUYdfyfK+qskThf4BQUSIadeI/dCsfaMZfNEoxm9HwOIioQ+LyqmMK6jWHAZQgOzMLaqawhuBXlF63vgjw==",
+      "version": "3.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-3.0.0-rc.1.tgz",
+      "integrity": "sha512-GbofumhCUb7SxP410j/fbtR2M9Zml+eoZSdaliZh6R3NhfEj5zP4jcO3HG3S9C9KIcXQQtd/cwVHkb9Y0KU7Hg==",
       "requires": {
-        "babel-runtime": "^6.26.0",
+        "classnames": "2.x",
         "dom-align": "^1.7.0",
-        "prop-types": "^15.5.8",
-        "rc-util": "^4.0.4"
+        "rc-util": "^4.12.0",
+        "resize-observer-polyfill": "^1.5.1"
       }
     },
     "rc-animate": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.10.2.tgz",
-      "integrity": "sha512-cE/A7piAzoWFSgUD69NmmMraqCeqVBa51UErod8NS3LUEqWfppSVagHfa0qHAlwPVPiIBg3emRONyny3eiH0Dg==",
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.10.3.tgz",
+      "integrity": "sha512-A9qQ5Y8BLlM7EhuCO3fWb/dChndlbWtY/P5QvPqBU7h4r5Q2QsvsbpTGgdYZATRDZbTRnJXXfVk9UtlyS7MBLg==",
       "requires": {
         "babel-runtime": "6.x",
         "classnames": "^2.2.6",
@@ -16656,31 +16556,14 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
-    "rc-calendar": {
-      "version": "9.15.9",
-      "resolved": "https://registry.npmjs.org/rc-calendar/-/rc-calendar-9.15.9.tgz",
-      "integrity": "sha512-XOPzJlXYmLFIcwalXmzxKZrrAMD6dEPLRVoHG3wbBpErqjE8ugnXVjm9yXgtQh3Ho3Imhmt+KO0WGLv5T4WuAA==",
-      "requires": {
-        "babel-runtime": "6.x",
-        "classnames": "2.x",
-        "moment": "2.x",
-        "prop-types": "^15.5.8",
-        "rc-trigger": "^2.2.0",
-        "rc-util": "^4.1.1",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
     "rc-cascader": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-0.17.5.tgz",
-      "integrity": "sha512-WYMVcxU0+Lj+xLr4YYH0+yXODumvNXDcVEs5i7L1mtpWwYkubPV/zbQpn+jGKFCIW/hOhjkU4J1db8/P/UKE7A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-1.0.1.tgz",
+      "integrity": "sha512-3mk33+YKJBP1XSrTYbdVLuCC73rUDq5STNALhvua5i8vyIgIxtb5fSl96JdWWq1Oj8tIBoHnCgoEoOYnIXkthQ==",
       "requires": {
         "array-tree-filter": "^2.1.0",
-        "prop-types": "^15.5.8",
-        "rc-trigger": "^2.2.0",
+        "rc-trigger": "^4.0.0",
         "rc-util": "^4.0.4",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallow-equal": "^1.0.0",
         "warning": "^4.0.1"
       }
     },
@@ -16730,59 +16613,34 @@
       }
     },
     "rc-dropdown": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-2.4.1.tgz",
-      "integrity": "sha512-p0XYn0wrOpAZ2fUGE6YJ6U8JBNc5ASijznZ6dkojdaEfQJAeZtV9KMEewhxkVlxGSbbdXe10ptjBlTEW9vEwEg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-3.0.1.tgz",
+      "integrity": "sha512-TbfTvJwFAaP1vPX/A/uxS07vbn2OqbHak9KJIL6Tdb0sV+sFXaIRo0udJixljkplbgPkLiasy8Xqnk1MGMfa0Q==",
       "requires": {
         "babel-runtime": "^6.26.0",
         "classnames": "^2.2.6",
-        "prop-types": "^15.5.8",
-        "rc-trigger": "^2.5.1",
-        "react-lifecycles-compat": "^3.0.2"
+        "rc-trigger": "^4.0.0"
       }
     },
-    "rc-editor-core": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/rc-editor-core/-/rc-editor-core-0.8.10.tgz",
-      "integrity": "sha512-T3aHpeMCIYA1sdAI7ynHHjXy5fqp83uPlD68ovZ0oClTSc3tbHmyCxXlA+Ti4YgmcpCYv7avF6a+TIbAka53kw==",
+    "rc-field-form": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.0.0.tgz",
+      "integrity": "sha512-yPgmQjE8aRGwkTl2UsG18UBghekqux9SFfjxWHd80MugGeLpmCJwtwK98bxWhhVELu1YhZtrQQ5EHiNEWptYZg==",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "classnames": "^2.2.5",
-        "draft-js": "^0.10.0",
-        "immutable": "^3.7.4",
-        "lodash": "^4.16.5",
-        "prop-types": "^15.5.8",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "rc-editor-mention": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/rc-editor-mention/-/rc-editor-mention-1.1.13.tgz",
-      "integrity": "sha512-3AOmGir91Fi2ogfRRaXLtqlNuIwQpvla7oUnGHS1+3eo7b+fUp5IlKcagqtwUBB5oDNofoySXkLBxzWvSYNp/Q==",
-      "requires": {
-        "babel-runtime": "^6.23.0",
-        "classnames": "^2.2.5",
-        "dom-scroll-into-view": "^1.2.0",
-        "draft-js": "~0.10.0",
-        "immutable": "~3.7.4",
-        "prop-types": "^15.5.8",
-        "rc-animate": "^2.3.0",
-        "rc-editor-core": "~0.8.3"
-      }
-    },
-    "rc-form": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/rc-form/-/rc-form-2.4.11.tgz",
-      "integrity": "sha512-8BL+FNlFLTOY/A5X6tU35GQJLSIpsmqpwn/tFAYQTczXc4dMJ33ggtH248Cum8+LS0jLTsJKG2L4Qp+1CkY+sA==",
-      "requires": {
-        "async-validator": "~1.11.3",
-        "babel-runtime": "6.x",
-        "create-react-class": "^15.5.3",
-        "dom-scroll-into-view": "1.x",
-        "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.4",
-        "rc-util": "^4.15.3",
+        "@babel/runtime": "^7.8.4",
+        "async-validator": "^3.0.3",
+        "rc-util": "^4.17.0",
         "warning": "^4.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.8.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+          "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "rc-hammerjs": {
@@ -16796,9 +16654,9 @@
       }
     },
     "rc-input-number": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-4.5.3.tgz",
-      "integrity": "sha512-jBwxX5KDkp2nHOaEoMQ1mZBwWpmmGUuHXF/qralpmN+wDp8rlB6Xvr9d7AHgmzGZhbWIMyLeq6ET6HDDCCjvAA==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-4.5.6.tgz",
+      "integrity": "sha512-AXbL4gtQ1mSQnu6v/JtMv3UbGRCzLvQznmf0a7U/SAtZ8+dCEAqD4JpJhkjv73Wog53eRYhw4l7ApdXflc9ymg==",
       "requires": {
         "babel-runtime": "6.x",
         "classnames": "^2.2.0",
@@ -16808,55 +16666,59 @@
       }
     },
     "rc-mentions": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-0.4.2.tgz",
-      "integrity": "sha512-DTZurQzacLXOfVuiHydGzqkq7cFMHXF18l2jZ9PhWUn2cqvOSY3W4osN0Pq29AOMOBpcxdZCzgc7Lb0r/bgkDw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-1.0.1.tgz",
+      "integrity": "sha512-EgXFYsNHk44ifwDcbtd3zX7rJc3lHplfVEVEf8oxZeeyyIzFD0GLs0Z0LWHNs6Gm4wTAHvcR0j4Pd5M7fLtBoA==",
       "requires": {
-        "@ant-design/create-react-context": "^0.2.4",
         "classnames": "^2.2.6",
-        "rc-menu": "^7.4.22",
-        "rc-trigger": "^2.6.2",
-        "rc-util": "^4.6.0",
-        "react-lifecycles-compat": "^3.0.4"
+        "rc-menu": "^8.0.1",
+        "rc-trigger": "^4.0.0",
+        "rc-util": "^4.6.0"
       }
     },
     "rc-menu": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-7.5.5.tgz",
-      "integrity": "sha512-4YJXJgrpUGEA1rMftXN7bDhrV5rPB8oBJoHqT+GVXtIWCanfQxEnM3fmhHQhatL59JoAFMZhJaNzhJIk4FUWCQ==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-8.0.2.tgz",
+      "integrity": "sha512-0zae6+LVQf+XTBepSMwwn2Wu+CvRf0eAVh62xl0UcjFBvyA0uGz+dAE0SVR6oUA0q9X+/G14CV1ItZFdwaP6/g==",
       "requires": {
         "classnames": "2.x",
-        "dom-scroll-into-view": "1.x",
         "mini-store": "^2.0.0",
-        "mutationobserver-shim": "^0.3.2",
         "rc-animate": "^2.10.1",
-        "rc-trigger": "^2.3.0",
+        "rc-trigger": "^4.0.0",
         "rc-util": "^4.13.0",
         "resize-observer-polyfill": "^1.5.0",
+        "scroll-into-view-if-needed": "^2.2.20",
         "shallowequal": "^1.1.0"
       }
     },
     "rc-notification": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-3.3.1.tgz",
-      "integrity": "sha512-U5+f4BmBVfMSf3OHSLyRagsJ74yKwlrQAtbbL5ijoA0F2C60BufwnOcHG18tVprd7iaIjzZt1TKMmQSYSvgrig==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-4.0.0.tgz",
+      "integrity": "sha512-In9FimkJY+JSIq3/eopPfBpQQr2Zugq5i9Aw9vdiNCGCsAsSO9bGq2dPsn8bamOydNrhc3djljGfmxUUMbcZnA==",
       "requires": {
-        "babel-runtime": "6.x",
         "classnames": "2.x",
-        "prop-types": "^15.5.8",
         "rc-animate": "2.x",
         "rc-util": "^4.0.4"
       }
     },
     "rc-pagination": {
-      "version": "1.20.13",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-1.20.13.tgz",
-      "integrity": "sha512-oocyyzx0pye957e3iARFg377hafdUc3oC13faGgmopGX/A8rn7tXCdOwVIJthhI6dHVfAcFLgnYQAlcpGXh+Uw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-2.0.1.tgz",
+      "integrity": "sha512-jvLb05p1OEBUxRobWFjnrj6vRyvhG8XHouK6qh+eepCHPo7HDzUHHztvUUAWr5f+WnKldAXqdPcGgbM4rCH1OA==",
       "requires": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.6",
-        "prop-types": "^15.5.7",
-        "react-lifecycles-compat": "^3.0.4"
+        "classnames": "^2.2.1"
+      }
+    },
+    "rc-picker": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-1.1.2.tgz",
+      "integrity": "sha512-B4z1cqla4bZlVUcMuyeFmyPPx9eumpYd06gYFzLKsl5Yz3h1jTmW40hW1uxxUgPkeg6ym1X5TjUoB3ZOveHuMQ==",
+      "requires": {
+        "classnames": "^2.2.1",
+        "dayjs": "^1.8.18",
+        "moment": "^2.24.0",
+        "rc-trigger": "^4.0.0",
+        "rc-util": "^4.17.0"
       }
     },
     "rc-progress": {
@@ -16890,35 +16752,28 @@
       }
     },
     "rc-select": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-9.2.3.tgz",
-      "integrity": "sha512-WhswxOMWiNnkXRbxyrj0kiIvyCfo/BaRPaYbsDetSIAU2yEDwKHF798blCP5u86KLOBKBvtxWLFCkSsQw1so5w==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-10.0.1.tgz",
+      "integrity": "sha512-DrBXl0pvNwiRssgHqJTgS61NPYlbkgNI6MAqJfd9qzm3RPQEHjSLFEU2hwRRJG1pzo46Dg7J94b+XbzWMDYo9Q==",
       "requires": {
-        "babel-runtime": "^6.23.0",
         "classnames": "2.x",
-        "component-classes": "1.x",
-        "dom-scroll-into-view": "1.x",
-        "prop-types": "^15.5.8",
-        "raf": "^3.4.0",
-        "rc-animate": "2.x",
-        "rc-menu": "^7.3.0",
-        "rc-trigger": "^2.5.4",
-        "rc-util": "^4.0.4",
-        "react-lifecycles-compat": "^3.0.2",
-        "warning": "^4.0.2"
+        "rc-animate": "^2.10.0",
+        "rc-trigger": "^4.0.0",
+        "rc-util": "^4.17.0",
+        "rc-virtual-list": "^1.0.0",
+        "warning": "^4.0.3"
       }
     },
     "rc-slider": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-8.7.1.tgz",
-      "integrity": "sha512-WMT5mRFUEcrLWwTxsyS8jYmlaMsTVCZIGENLikHsNv+tE8ThU2lCoPfi/xFNUfJFNFSBFP3MwPez9ZsJmNp13g==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-9.2.2.tgz",
+      "integrity": "sha512-WwdNHb/cvnQXMhp8cRhxOM0pGnVG4fPoaFE31yVkyJUAZiHq3siQgwzAeYl11fyszwhrEXkpGU7tEAfClh0AaQ==",
       "requires": {
         "babel-runtime": "6.x",
         "classnames": "^2.2.5",
         "prop-types": "^15.5.4",
-        "rc-tooltip": "^3.7.0",
+        "rc-tooltip": "^4.0.0",
         "rc-util": "^4.0.4",
-        "react-lifecycles-compat": "^3.0.4",
         "shallowequal": "^1.1.0",
         "warning": "^4.0.3"
       }
@@ -16945,26 +16800,27 @@
       }
     },
     "rc-table": {
-      "version": "6.10.11",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-6.10.11.tgz",
-      "integrity": "sha512-YcTlpO4RKlcM7Mio2FjcUOqRUyGU4edtOBG4x5kwZNHwZdfBm7m6VQuyQ/i6qec5S67EP86wiFbmKU54Z2HtFQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.0.0.tgz",
+      "integrity": "sha512-XVoRsJ1r3Oh1zl8vxVNBD/+4ZFL5hpHcEwEBpJLJ+I+N2uM/fnAYASHqYEkBdvCRv7l0nG0qTeFOB4dQQAHuLA==",
       "requires": {
         "classnames": "^2.2.5",
         "component-classes": "^1.2.6",
         "lodash": "^4.17.5",
         "mini-store": "^2.0.0",
         "prop-types": "^15.5.8",
-        "rc-util": "^4.13.0",
+        "raf": "^3.4.1",
+        "rc-resize-observer": "^0.1.2",
+        "rc-util": "^4.19.0",
         "react-lifecycles-compat": "^3.0.2",
-        "shallowequal": "^1.0.2"
+        "shallowequal": "^1.1.0"
       }
     },
     "rc-tabs": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-9.7.0.tgz",
-      "integrity": "sha512-kvmgp8/MfLzFZ06hWHignqomFQ5nF7BqKr5O1FfhE4VKsGrep52YSF/1MvS5oe0NPcI9XGNS2p751C5v6cYDpQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-10.0.0.tgz",
+      "integrity": "sha512-kpYho3S8GqHVKuFvsYyShN4GSM+f3RMfgwxmR4lpXA79lzPmIlaLamCGtTnMAOXOVTS3JEltWQCWC8LYY4ITIg==",
       "requires": {
-        "@ant-design/create-react-context": "^0.2.4",
         "babel-runtime": "6.x",
         "classnames": "2.x",
         "lodash": "^4.17.5",
@@ -16972,134 +16828,84 @@
         "raf": "^3.4.1",
         "rc-hammerjs": "~0.6.0",
         "rc-util": "^4.0.4",
-        "react-lifecycles-compat": "^3.0.4",
         "resize-observer-polyfill": "^1.5.1",
         "warning": "^4.0.3"
       }
     },
-    "rc-time-picker": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/rc-time-picker/-/rc-time-picker-3.7.3.tgz",
-      "integrity": "sha512-Lv1Mvzp9fRXhXEnRLO4nW6GLNxUkfAZ3RsiIBsWjGjXXvMNjdr4BX/ayElHAFK0DoJqOhm7c5tjmIYpEOwcUXg==",
-      "requires": {
-        "classnames": "2.x",
-        "moment": "2.x",
-        "prop-types": "^15.5.8",
-        "raf": "^3.4.1",
-        "rc-trigger": "^2.2.0",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
     "rc-tooltip": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-3.7.3.tgz",
-      "integrity": "sha512-dE2ibukxxkrde7wH9W8ozHKUO4aQnPZ6qBHtrTH9LoO836PjDdiaWO73fgPB05VfJs9FbZdmGPVEbXCeOP99Ww==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-4.0.1.tgz",
+      "integrity": "sha512-R+Ift6SwD2bJKhlYgKXyklvurnYwGzNMfRIPBqv0qoG0SYcVJDVuECL73dcRm2+CCik3YYn1ZGZLPjRRrUkAIw==",
       "requires": {
-        "babel-runtime": "6.x",
-        "prop-types": "^15.5.8",
-        "rc-trigger": "^2.2.2"
+        "rc-trigger": "^4.0.0"
       }
     },
     "rc-tree": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-2.1.3.tgz",
-      "integrity": "sha512-COvV65spQ6omrHBUhHRKqKNL5+ddXjlS+qWZchaL9FFuQNvjM5pjp9RnmMWK4fJJ5kBhhpLneh6wh9Vh3kSMXQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-3.0.1.tgz",
+      "integrity": "sha512-v0B/aN8vikPGAcQoMm5jhxJ5eXj3V0HSHAoHJYXgdad4nqBVyWMDvSWDbZumdFQlBfKhpdGK02LnSgWx4W2SSA==",
       "requires": {
-        "@ant-design/create-react-context": "^0.2.4",
         "classnames": "2.x",
         "prop-types": "^15.5.8",
-        "rc-animate": "^2.6.0",
-        "rc-util": "^4.5.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "warning": "^4.0.3"
-      }
-    },
-    "rc-tree-select": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-2.9.4.tgz",
-      "integrity": "sha512-0HQkXAN4XbfBW20CZYh3G+V+VMrjX42XRtDCpyv6PDUm5vikC0Ob682ZBCVS97Ww2a5Hf6Ajmu0ahWEdIEpwhg==",
-      "requires": {
-        "classnames": "^2.2.1",
-        "dom-scroll-into-view": "^1.2.1",
-        "prop-types": "^15.5.8",
-        "raf": "^3.4.0",
-        "rc-animate": "^2.8.2",
-        "rc-tree": "~2.1.0",
-        "rc-trigger": "^3.0.0",
-        "rc-util": "^4.5.0",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.0.2",
-        "warning": "^4.0.1"
-      },
-      "dependencies": {
-        "rc-trigger": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-3.0.0.tgz",
-          "integrity": "sha512-hQxbbJpo23E2QnYczfq3Ec5J5tVl2mUDhkqxrEsQAqk16HfADQg+iKNWzEYXyERSncdxfnzYuaBgy764mNRzTA==",
-          "requires": {
-            "babel-runtime": "6.x",
-            "classnames": "^2.2.6",
-            "prop-types": "15.x",
-            "raf": "^3.4.0",
-            "rc-align": "^2.4.1",
-            "rc-animate": "^3.0.0-rc.1",
-            "rc-util": "^4.15.7"
-          },
-          "dependencies": {
-            "rc-animate": {
-              "version": "3.0.0-rc.6",
-              "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-3.0.0-rc.6.tgz",
-              "integrity": "sha512-oBLPpiT6Q4t6YvD/pkLcmofBP1p01TX0Otse8Q4+Mxt8J+VSDflLZGIgf62EwkvRwsQUkLPjZVFBsldnPKLzjg==",
-              "requires": {
-                "babel-runtime": "6.x",
-                "classnames": "^2.2.5",
-                "component-classes": "^1.2.6",
-                "fbjs": "^0.8.16",
-                "prop-types": "15.x",
-                "raf": "^3.4.0",
-                "rc-util": "^4.5.0",
-                "react-lifecycles-compat": "^3.0.4"
-              }
-            }
-          }
-        }
-      }
-    },
-    "rc-trigger": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.6.5.tgz",
-      "integrity": "sha512-m6Cts9hLeZWsTvWnuMm7oElhf+03GOjOLfTuU0QmdB9ZrW7jR2IpI5rpNM7i9MvAAlMAmTx5Zr7g3uu/aMvZAw==",
-      "requires": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.6",
-        "prop-types": "15.x",
-        "rc-align": "^2.4.0",
-        "rc-animate": "2.x",
-        "rc-util": "^4.4.0",
+        "rc-animate": "^2.9.2",
+        "rc-util": "^4.11.0",
+        "rc-virtual-list": "^1.0.0",
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "rc-tree-select": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-3.0.2.tgz",
+      "integrity": "sha512-xowQdNWEUAxtEfJa5X2jcO5iRB/25YlecLwcyPGn04EC0Idwmn94yaji8fM+2QSKWKqvoImppaiRJpA1uljAHg==",
+      "requires": {
+        "classnames": "2.x",
+        "rc-select": "^10.0.0",
+        "rc-tree": "^3.0.0",
+        "rc-util": "^4.17.0"
+      }
+    },
+    "rc-trigger": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.0.0.tgz",
+      "integrity": "sha512-wOr2i4UrhsLjPhT9/k3p8l5yktC0BjOIBk2afze78a9ieql4GEw19Qo6iqSBmX/KqD9V4VXQxD4Ebt7U7IDrIw==",
+      "requires": {
+        "classnames": "^2.2.6",
+        "prop-types": "15.x",
+        "raf": "^3.4.1",
+        "rc-align": "^3.0.0-rc.0",
+        "rc-animate": "^2.10.2",
+        "rc-util": "^4.15.2"
+      }
+    },
     "rc-upload": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-2.9.4.tgz",
-      "integrity": "sha512-WXt0HGxXyzLrPV6iec/96Rbl/6dyrAW8pKuY6wwD7yFYwfU5bjgKjv7vC8KNMJ6wzitFrZjnoiogNL3dF9dj3Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-3.0.0.tgz",
+      "integrity": "sha512-GTmLJ2Habrgon26xwtF8nx1FBxu8KUjRC6QW/7a+NVZ6qXIo+s7HnjqwseuG42kz6xGCoSLNpHgIoHW55EwpxA==",
       "requires": {
         "babel-runtime": "6.x",
-        "classnames": "^2.2.5",
-        "prop-types": "^15.5.7",
-        "warning": "4.x"
+        "classnames": "^2.2.5"
       }
     },
     "rc-util": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.19.0.tgz",
-      "integrity": "sha512-mptALlLwpeczS3nrv83DbwJNeupolbuvlIEjcvimSiWI8NUBjpF0HgG3kWp1RymiuiRCNm9yhaXqDz0a99dpgQ==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.20.0.tgz",
+      "integrity": "sha512-rUqk4RqtDe4OfTsSk2GpbvIQNVtfmmebw4Rn7ZAA1TO1zLMLfyOF78ZyrEKqs8RDwoE3S1aXp0AX0ogLfSxXrQ==",
       "requires": {
         "add-dom-event-listener": "^1.1.0",
         "babel-runtime": "6.x",
         "prop-types": "^15.5.10",
+        "react-is": "^16.12.0",
         "react-lifecycles-compat": "^3.0.4",
         "shallowequal": "^1.1.0"
+      }
+    },
+    "rc-virtual-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-1.0.0.tgz",
+      "integrity": "sha512-t6q0/GiH5qp5k2VRDeIrrS1Z2r8ey0fnVQN5HIu6ildvXqRfgm4MbNnUeoUywNt+et4XhDFBGmiEhRvIs6vujQ==",
+      "requires": {
+        "classnames": "^2.2.6",
+        "rc-util": "^4.8.0"
       }
     },
     "react": {
@@ -17355,17 +17161,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
       "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
     },
-    "react-lazy-load": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/react-lazy-load/-/react-lazy-load-3.0.13.tgz",
-      "integrity": "sha1-OwqS0zbUPT8Nc8vm81sXBQsIuCQ=",
-      "requires": {
-        "eventlistener": "0.0.1",
-        "lodash.debounce": "^4.0.0",
-        "lodash.throttle": "^4.0.0",
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -17500,18 +17295,6 @@
             "path-parse": "^1.0.6"
           }
         }
-      }
-    },
-    "react-slick": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.25.2.tgz",
-      "integrity": "sha512-8MNH/NFX/R7zF6W/w+FS5VXNyDusF+XDW1OU0SzODEU7wqYB+ZTGAiNJ++zVNAVqCAHdyCybScaUB+FCZOmBBw==",
-      "requires": {
-        "classnames": "^2.2.5",
-        "enquire.js": "^2.1.6",
-        "json2mq": "^0.2.0",
-        "lodash.debounce": "^4.0.8",
-        "resize-observer-polyfill": "^1.5.0"
       }
     },
     "read-cache": {
@@ -18192,7 +17975,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sane": {
       "version": "4.1.0",
@@ -18491,6 +18275,14 @@
         "ajv-keywords": "^3.4.1"
       }
     },
+    "scroll-into-view-if-needed": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.24.tgz",
+      "integrity": "sha512-vsC6SzyIZUyJG8o4nbUDCiIwsPdH6W/FVmjT2avR2hp/yzS53JjGmg/bKD20TkoNajbu5dAQN4xR7yes4qhwtQ==",
+      "requires": {
+        "compute-scroll-into-view": "^1.0.13"
+      }
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -18669,7 +18461,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -18715,11 +18508,6 @@
           "dev": true
         }
       }
-    },
-    "shallow-equal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "shallowequal": {
       "version": "1.1.0",
@@ -20192,11 +19980,6 @@
       "requires": {
         "typescript-compare": "^0.0.2"
       }
-    },
-    "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -22625,7 +22408,8 @@
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@lingui/macro": "^2.9.1",
     "@lingui/react": "^2.9.1",
     "@reduxjs/toolkit": "^1.2.5",
-    "antd": "^3.26.9",
+    "antd": "^4.0.0",
     "axios": "^0.19.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",


### PR DESCRIPTION
Reduces initial bundle size by **57%** (848 KB => 368KB) following the Icons refactoring in Ant v4 (https://github.com/ant-design/ant-design/issues/21656)

Before
![image](https://user-images.githubusercontent.com/1767282/75541543-795edc00-5a1e-11ea-9f8a-22ec7bfb6b74.png)

After
![image](https://user-images.githubusercontent.com/1767282/75541851-e2deea80-5a1e-11ea-9242-3b19cf510282.png)
